### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,27 +22,47 @@ Config in `book.json`:
 
 ## Usage
 
-Insert block in your markdown file:
+Insert block in your markdown file.
+
+**Caution**: the content of the blocks should be written in pure JSON. That is, each property should be quoted, and you should strictly use double quotes `"`, not single quotes `'`:
+```JSON
+// Invalid JSON
+{
+    data: {
+        type: 'bar'
+    }
+}
+
+// Valid JSON
+{
+    "data": {
+        "type": "bar"
+    }
+}
+```
+
+See the examples below.
 
 ### Example for [C3.js](http://c3js.org/)
+
+You SHOULD NOT specify the `bindto` property for the chart.
 
 ```
 {% chart %}
 {
-    // NOT need to specified `bindto` here
-    data: {
-        type: 'bar',
-        columns: [
-            ['data1', 30, 200, 100, 400, 150, 250],
-            ['data2', 50, 20, 10, 40, 15, 25]
+    "data": {
+        "type": "bar",
+        "columns": [
+            ["data1", 30, 200, 100, 400, 150, 250],
+            ["data2", 50, 20, 10, 40, 15, 25]
         ],
-        axes: {
-            data2: 'y2'
+        "axes": {
+            "data2": "y2"
         }
     },
-    axis: {
-        y2: {
-            show: true
+    "axis": {
+        "y2": {
+            "show": true
         }
     }
 }
@@ -70,30 +90,31 @@ Getting Start with [C3.js](http://c3js.org/gettingstarted.html#customize).
 
 ### Example for [Highcharts](http://www.highcharts.com/)
 
+You SHOULD NOT specify the `renderTo` property for the chart.
+
 ```
 {% chart %}
 {
-    chart: {
-        // NOT need to specified `renderTo` here
-        type: 'bar'
+    "chart": {
+        "type": "bar"
     },
-    title: {
-        text: 'Fruit Consumption'
+    "title": {
+        "text": "Fruit Consumption"
     },
-    xAxis: {
-        categories: ['Apples', 'Bananas', 'Oranges']
+    "xAxis": {
+        "categories": ["Apples", "Bananas", "Oranges"]
     },
-    yAxis: {
-        title: {
-            text: 'Fruit eaten'
+    "yAxis": {
+        "title": {
+            "text": "Fruit eaten"
         }
     },
-    series: [{
-        name: 'Jane',
-        data: [1, 0, 4]
+    "series": [{
+        "name": "Jane",
+        "data": [1, 0, 4]
     }, {
-        name: 'John',
-        data: [5, 7, 3]
+        "name": "John",
+        "data": [5, 7, 3]
     }]
 }
 {% endchart %}

--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,12 @@
+{% extends template.self %}
+
+{% block head %}
+    {{ super() }}
+    {% if config.pluginsConfig.chart.type == 'highcharts' %}
+    <script src="{{ 'gitbook-plugin-chart/highcharts/highcharts.js'|resolveAsset }}"></script>
+    {% else %}
+    <link rel="stylesheet" href="{{ 'gitbook-plugin-chart/c3/c3.min.css'|resolveAsset }}">
+    <script src="{{ 'gitbook-plugin-chart/c3/d3.min.js'|resolveAsset }}"></script>
+    <script src="{{ 'gitbook-plugin-chart/c3/c3.min.js'|resolveAsset }}"></script>
+    {% endif %}
+{% endblock %}

--- a/build/index.js
+++ b/build/index.js
@@ -1,24 +1,8 @@
 'use strict';
 
-var path = require('path');
-path = 'default' in path ? path['default'] : path;
-
 var _uuidCounter = 0;
 function uuid() {
-    return 'plugin-chart-' + ++_uuidCounter;
-};
-
-var PKG = require('../package.json');
-function assetsTag(staticBase, fileName) {
-    var filePath = staticBase + '/plugins/' + PKG.name + '/' + fileName;
-    switch (path.extname(fileName)) {
-        case '.js':
-            return '<script src="' + filePath + '"></script>';
-        case '.css':
-            return '<link rel="stylesheet" href="' + filePath + '">';
-        default:
-            return '';
-    }
+    return "plugin-chart-" + ++_uuidCounter;
 };
 
 function c3(id, body) {
@@ -41,35 +25,16 @@ var chartFns = Object.freeze({
 
 var FORMAT_YAML = 'yaml';
 
-var CHART_TYPE = ['c3', 'highcharts'];
-
-var ASSETS_SCRIPT_FILES = {
-    c3: ['c3/c3.min.css', 'c3/d3.min.js', 'c3/c3.min.js'],
-    highcharts: ['highcharts/highcharts.js']
-};
-
-var assetsFiles = [];
 var chartScriptFn = function chartScriptFn() {};
 
 module.exports = {
     book: {
-        assets: './assets',
-        html: {
-            'head:end': function headEnd(options) {
-                return assetsFiles.map(function (f) {
-                    return assetsTag(options.staticBase, f);
-                }).join('');
-            }
-        }
+        assets: './assets'
     },
     hooks: {
         init: function init() {
-            var pluginConfig = (this.options.pluginsConfig || {}).chart || {};
+            var pluginConfig = this.config.get('pluginsConfig.chart');
             var type = pluginConfig.type;
-            if (CHART_TYPE.indexOf(type) < 0) {
-                type = CHART_TYPE[0];
-            }
-            assetsFiles = ASSETS_SCRIPT_FILES[type];
             chartScriptFn = chartFns[type];
         }
     },
@@ -85,10 +50,8 @@ module.exports = {
                         // load yaml into body:
                         body = require('js-yaml').safeLoad(bodyString);
                     } else {
-                        // just think it as json:
-                        // TODO: Avoiding `eval`
-                        // https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval
-                        eval('body=' + bodyString);
+                        // this is pure JSON
+                        body = JSON.parse(bodyString);
                     }
                 } catch (e) {
                     console.error(e);

--- a/package.json
+++ b/package.json
@@ -32,5 +32,15 @@
   },
   "dependencies": {
     "js-yaml": "^3.5.2"
+  },
+  "gitbook": {
+    "properties": {
+      "type": {
+        "type": "string",
+        "description": "Chart library",
+        "enum": ["c3", "highcharts"],
+        "default": "c3"
+      }
+    }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,47 +1,19 @@
 
-import { uuid, assetsTag } from './util';
+import { uuid } from './util';
 import * as chartFns from './chart';
 
 const FORMAT_YAML = 'yaml';
 
-const CHART_TYPE = [
-    'c3',
-    'highcharts'
-];
-
-const ASSETS_SCRIPT_FILES = {
-    c3: [
-        'c3/c3.min.css',
-        'c3/d3.min.js',
-        'c3/c3.min.js',
-    ],
-    highcharts: [
-        'highcharts/highcharts.js'
-    ]
-};
-
-let assetsFiles = [];
 let chartScriptFn = () => {};
 
 module.exports = {
     book: {
-        assets: './assets',
-        html: {
-            'head:end': function (options) {
-                return assetsFiles
-                    .map(f => assetsTag(options.staticBase, f))
-                    .join('');
-            }
-        }
+        assets: './assets'
     },
     hooks: {
         init: function () {
             let pluginConfig = (this.options.pluginsConfig || {}).chart || {};
             let type = pluginConfig.type;
-            if (CHART_TYPE.indexOf(type) < 0) {
-                type = CHART_TYPE[0];
-            }
-            assetsFiles = ASSETS_SCRIPT_FILES[type];
             chartScriptFn = chartFns[type];
         }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -29,10 +29,8 @@ module.exports = {
                         // load yaml into body:
                         body = require('js-yaml').safeLoad(bodyString);
                     } else {
-                        // just think it as json:
-                        // TODO: Avoiding `eval`
-                        // https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval
-                        eval('body=' + bodyString);
+                        // this is pure JSON
+                        body = JSON.parse(bodyString);
                     }
                 } catch (e) {
                     console.error(e);

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ module.exports = {
     },
     hooks: {
         init: function () {
-            let pluginConfig = (this.options.pluginsConfig || {}).chart || {};
+            let pluginConfig = this.config.get('pluginsConfig.chart');
             let type = pluginConfig.type;
             chartScriptFn = chartFns[type];
         }

--- a/src/util.js
+++ b/src/util.js
@@ -1,21 +1,4 @@
-import path from 'path';
-
 let _uuidCounter = 0;
 export function uuid() {
     return `plugin-chart-${++_uuidCounter}`;
 };
-
-
-const PKG = require('../package.json');
-export function assetsTag (staticBase, fileName) {
-    let filePath = `${staticBase}/plugins/${PKG.name}/${fileName}`;
-    switch (path.extname(fileName)) {
-        case '.js':
-            return `<script src="${filePath}"></script>`;
-        case '.css':
-            return `<link rel="stylesheet" href="${filePath}">`;
-        default:
-            return '';
-    }
-};
-


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used for this plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version and directly includes the scripts and stylesheets using GitBook 3 templating.

I also added the plugin configuration to the `package.json`. This allows GitBook to validate the configuration before running, so we don't have to execute it ourselves. Plus this gives users informations on [plugins.gitbook.com](https://plugins.gitbook.com).

Finally, I used `JSON.parse()` on blocks body to prevent using `eval()`. For this purpose, the code blocks should be using strict JSON. Hence, I updated the README to reflect this.

Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

If you release a new version, please upgrade the gitbook engine in `package.json`:
```JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan