### PR TITLE
Added the removal of escaped angle brackets before parsing the json document

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,13 @@ function c3(id, bodyString) {
 }
 function highcharts(id, bodyString) {
   try {
+
+    // In some cases bodyString contains escape characters right before the array brackets
+    // \[ \]
+    // These escape characters must be removed before parsing the json document.
+    bodyString = bodyString.replace(/\\\[/g, '[');
+    bodyString = bodyString.replace(/\\\]/g, ']');
+
     var body = JSON.parse(bodyString); // http://www.highcharts.com/docs/getting-started/your-first-chart
 
     body.chart = body.chart || {};


### PR DESCRIPTION
In some environments we saw the bodyString containing escaped angle brackets. We could not figure out why this happens and so we added a simple fix by replacing the escaped brackets by non escaped brackets. It would be great if could accept this pr as soon as possible. Or maybe you know the root cause?